### PR TITLE
Implement improved autoencoder and ensemble strategy

### DIFF
--- a/test.py
+++ b/test.py
@@ -90,7 +90,7 @@ def test_advanced_pseudo_labeling():
         )
         
         # 生成伪标签
-        pseudo_features, pseudo_targets, pseudo_weights, stats = generator.generate_pseudo_labels(
+        pseudo_features, pseudo_targets, pseudo_weights, unc, stats = generator.generate_pseudo_labels(
             X_unlabeled=X_unlabeled,
             ensemble_estimator=ensemble_estimator,
             autoencoder_trainer=vae_trainer,


### PR DESCRIPTION
## Summary
- boost latent dimension and lighten dropout
- tighten pseudo label filtering and scoring
- simplify feature processing with StandardScaler and PCA
- add KL annealing in VAE trainer
- use weighted soft voting in ensembles
- adjust tests for new APIs

## Testing
- `python test.py`

------
https://chatgpt.com/codex/tasks/task_e_68496163e26c83269604b73665aef509